### PR TITLE
Slight structural changes for clarity

### DIFF
--- a/FSL-DRAFT-Apache-2.0.template.md
+++ b/FSL-DRAFT-Apache-2.0.template.md
@@ -4,19 +4,19 @@
 
 FSL-DRAFT-Apache-2.0
 
-## TERMS AND CONDITIONS
-
-### Notice
+## Notice
 
 Copyright ${year} ${licensor name}
 
-### Licensor (“We”)
+## Terms and Conditions
+
+### Licensor ("We")
 
 The party offering the Software under these Terms and Conditions.
 
 ### The Software
 
-The “Software” is each version of the software that we make available under
+The "Software" is each version of the software that we make available under
 these Terms and Conditions, as indicated by our inclusion of these Terms and
 Conditions with the Software.
 
@@ -74,7 +74,7 @@ remove any copyright notices provided in or with the Software.
 
 ### Disclaimer
 
-THE SOFTWARE IS PROVIDED “AS IS” AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
 PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
 
@@ -88,7 +88,7 @@ Except for displaying the License Details and identifying us as the origin of
 the Software, you have no right under these Terms and Conditions to use our
 trademarks, trade names, service marks or product names.
 
-### Change License
+## Change License
 
 On the second anniversary of the date we make the Software available, the
 Software will become available under the Apache 2.0 license. On that date, the

--- a/FSL-DRAFT-MIT.template.md
+++ b/FSL-DRAFT-MIT.template.md
@@ -4,19 +4,19 @@
 
 FSL-DRAFT-MIT
 
-## TERMS AND CONDITIONS
-
-### Notice
+## Notice
 
 Copyright ${year} ${licensor name}
 
-### Licensor (“We”)
+## Terms and Conditions
+
+### Licensor ("We")
 
 The party offering the Software under these Terms and Conditions.
 
 ### The Software
 
-The “Software” is each version of the software that we make available under
+The "Software" is each version of the software that we make available under
 these Terms and Conditions, as indicated by our inclusion of these Terms and
 Conditions with the Software.
 
@@ -74,7 +74,7 @@ remove any copyright notices provided in or with the Software.
 
 ### Disclaimer
 
-THE SOFTWARE IS PROVIDED “AS IS” AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
 PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
 
@@ -88,7 +88,7 @@ Except for displaying the License Details and identifying us as the origin of
 the Software, you have no right under these Terms and Conditions to use our
 trademarks, trade names, service marks or product names.
 
-### Change License
+## Change License
 
 On the second anniversary of the date we make the Software available, the
 Software will become available under the MIT license. On that date, the Terms
@@ -96,7 +96,7 @@ and Conditions above automatically terminate and the following terms become
 effective:
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the “Software”), to deal in
+this software and associated documentation files (the "Software"), to deal in
 the Software without restriction, including without limitation the rights to
 use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 of the Software, and to permit persons to whom the Software is furnished to do
@@ -105,7 +105,7 @@ so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER


### PR DESCRIPTION
- Bumps Change License up to H2, because refers to "the Terms and Conditions above" so it should not itself be a term or condition.
- Bumps Notice up to H2, because MIT refers to the "above copyright notice," so that section should survive even when the Terms and Conditions terminate.
- Changes smart quotes to ASCII quotes.
- Normalizes casing on Terms and Conditions (we're using Markdown for structure).